### PR TITLE
#26 Fixing string cast problem for object_id_field.

### DIFF
--- a/src/main/java/org/opensearch/ubi/UbiActionFilter.java
+++ b/src/main/java/org/opensearch/ubi/UbiActionFilter.java
@@ -130,7 +130,8 @@ public class UbiActionFilter implements ActionFilter {
                                 queryResponseHitIds.add(String.valueOf(hit.docId()));
                             } else {
                                 final Map<String, Object> source = hit.getSourceAsMap();
-                                queryResponseHitIds.add((String) source.get(objectIdField));
+                                final List<String> objectIds = (List<String>) source.get(objectIdField);
+                                queryResponseHitIds.addAll(objectIds);
                             }
 
                         }


### PR DESCRIPTION
### Description
Fixes string cast when providing an `object_id_field` in the search request's `ext`.

### Issues Resolved
#26 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
