### PR TITLE
Changing query and event timestamp formats to `strict_date_time`

### DIFF
--- a/src/main/java/org/opensearch/ubi/QueryRequest.java
+++ b/src/main/java/org/opensearch/ubi/QueryRequest.java
@@ -13,6 +13,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.security.AccessController;
 import java.security.PrivilegedAction;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Locale;
 import java.util.Map;
 
 /**
@@ -20,7 +23,7 @@ import java.util.Map;
  */
 public class QueryRequest {
 
-    private final long timestamp;
+    private final String timestamp;
     private final String queryId;
     private final String clientId;
     private final String userQuery;
@@ -40,7 +43,8 @@ public class QueryRequest {
     public QueryRequest(final String queryId, final String userQuery, final String clientId, final String query,
                         final Map<String, String> queryAttributes, final QueryResponse queryResponse) {
 
-        this.timestamp = System.currentTimeMillis();
+        final SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ", Locale.getDefault());
+        this.timestamp = sdf.format(new Date());
         this.queryId = queryId;
         this.clientId = clientId;
         this.userQuery = userQuery;
@@ -79,7 +83,7 @@ public class QueryRequest {
      * Gets the timestamp.
      * @return The timestamp.
      */
-    public long getTimestamp() {
+    public String getTimestamp() {
         return timestamp;
     }
 

--- a/src/main/java/org/opensearch/ubi/QueryRequest.java
+++ b/src/main/java/org/opensearch/ubi/QueryRequest.java
@@ -31,6 +31,8 @@ public class QueryRequest {
     private final Map<String, String> queryAttributes;
     private final QueryResponse queryResponse;
 
+    private static final SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ", Locale.getDefault());
+
     /**
      * Creates a query request.
      * @param queryId The ID of the query.
@@ -43,7 +45,6 @@ public class QueryRequest {
     public QueryRequest(final String queryId, final String userQuery, final String clientId, final String query,
                         final Map<String, String> queryAttributes, final QueryResponse queryResponse) {
 
-        final SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ", Locale.getDefault());
         this.timestamp = sdf.format(new Date());
         this.queryId = queryId;
         this.clientId = clientId;

--- a/src/main/resources/events-mapping.json
+++ b/src/main/resources/events-mapping.json
@@ -7,7 +7,7 @@
     "message_type": { "type": "keyword", "ignore_above": 100 },
     "timestamp": {
       "type": "date",
-      "format":"rfc3339_lenient||epoch_millis",
+      "format":"strict_date_time",
       "ignore_malformed": true, 
       "doc_values": true
     },

--- a/src/main/resources/queries-mapping.json
+++ b/src/main/resources/queries-mapping.json
@@ -1,7 +1,7 @@
 {
   "dynamic": false,
   "properties": {
-    "timestamp": { "type": "date" },
+    "timestamp": { "type": "date", "format": "strict_date_time" },
     "query_id": { "type": "keyword", "ignore_above": 100 },
     "query": { "type": "text" },
     "query_response_id": { "type": "keyword", "ignore_above": 100 },

--- a/src/yamlRestTest/resources/rest-api-spec/test/_plugins.ubi/20_queries_with_ubi.yml
+++ b/src/yamlRestTest/resources/rest-api-spec/test/_plugins.ubi/20_queries_with_ubi.yml
@@ -6,7 +6,7 @@
         index: ecommerce
         body:
           mappings:
-            { "properties": { "category": { "type": "text" } } }
+            { "properties": { "category": { "type": "text" }, "timestamp": { "type": "date", "format": "strict_date_time" } } }
 
   - match: { acknowledged: true }
   - match: { index: "ecommerce"}

--- a/src/yamlRestTest/resources/rest-api-spec/test/_plugins.ubi/30_msearch_queries_with_ubi.yml
+++ b/src/yamlRestTest/resources/rest-api-spec/test/_plugins.ubi/30_msearch_queries_with_ubi.yml
@@ -11,7 +11,7 @@
         index: ecommerce1
         body:
           mappings:
-            { "properties": { "category": { "type": "text" } } }
+            { "properties": { "category": { "type": "text" }, "timestamp": { "type": "date", "format": "strict_date_time" } } }
 
   - match: { acknowledged: true }
   - match: { index: "ecommerce1"}


### PR DESCRIPTION
### Description
Changes query and event timestamp formats to `strict_date_time`

### Issues Resolved
#37 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
