### PR TITLE
Changing user_query mapping to keyword.

### DIFF
--- a/src/main/resources/queries-mapping.json
+++ b/src/main/resources/queries-mapping.json
@@ -6,9 +6,7 @@
     "query": { "type": "text" },
     "query_response_id": { "type": "keyword", "ignore_above": 100 },
     "query_response_hit_ids": { "type": "keyword" },
-    "user_query": { "type": "text",
-      "fields": { "keyword": { "type": "keyword", "ignore_above": 256 } }
-    },
+    "user_query":  { "type": "keyword" },
     "query_attributes": { "type": "flat_object" },
     "client_id": { "type": "keyword", "ignore_above": 100 },
     "application":  { "type":  "keyword", "ignore_above": 100 }


### PR DESCRIPTION
### Description
Fixes the mapping for `user_query` in the `ubi_queries` index.

### Issues Resolved
Closes #54 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
