### PR TITLE
Rename view to impression and OpenSearch parameters…

### DIFF
--- a/ubi-data-generator/ubi_data_generator.py
+++ b/ubi-data-generator/ubi_data_generator.py
@@ -332,7 +332,7 @@ def make_ubi_event(gen_config, row):
                 "object_id_field": row["object_id_field"],
             },
             "position": {
-                "index": row["position"],
+                "ordinal": row["position"],
             },
         }
     }

--- a/ubi-data-generator/ubi_data_generator.py
+++ b/ubi-data-generator/ubi_data_generator.py
@@ -230,6 +230,7 @@ def simulate_events(gen_config, top_queries, result_sample_per_query):
         judg_df["application"] = gen_config.application
         judg_df["action_name"] = "impression"
         judg_df["query_id"] = query_id
+        judg_df["user_query"] = q
         judg_df["session_id"] = session_id
         judg_df["client_id"] = client_id
         judg_df["timestamp"] = formatted_current_time
@@ -324,6 +325,7 @@ def make_ubi_event(gen_config, row):
         "session_id": row["session_id"],
         "client_id": row["client_id"],
         "timestamp": row["timestamp"],
+        "user_query": row["user_query"],
         "message_type": None,
         "message": None,
         "event_attributes": {

--- a/ubi-data-generator/ubi_data_generator.py
+++ b/ubi-data-generator/ubi_data_generator.py
@@ -330,8 +330,8 @@ def make_ubi_event(gen_config, row):
             "object": {
                 "object_id": row["object_id"],
                 "object_id_field": row["object_id_field"],
-                "rank": row["rank"],
             },
+            "rank": row["rank"],
         }
     }
     return ubi_event

--- a/ubi-data-generator/ubi_data_generator.py
+++ b/ubi-data-generator/ubi_data_generator.py
@@ -331,7 +331,9 @@ def make_ubi_event(gen_config, row):
                 "object_id": row["object_id"],
                 "object_id_field": row["object_id_field"],
             },
-            "rank": row["rank"],
+            "position": {
+                "index": row["rank"],
+            },
         }
     }
     return ubi_event


### PR DESCRIPTION
… to align with latest developments in Chorus event tracking

### Description
Some renaming operations that aim to align the data generation script with how things are tracked in Chorus with the extended ESCI dataset.

*  `view` is now called `impression` 
* Additionally, the `open-search` or `open_search` or `Open Search` occurrences are renamed to contain neither space, dash nor underscore to align with the naming within OpenSearch

### Issues Resolved
n/a

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
