### PR TITLE
add user_query to events-mapping.json file

### DIFF
--- a/src/main/resources/events-mapping.json
+++ b/src/main/resources/events-mapping.json
@@ -6,6 +6,7 @@
     "query_id": { "type": "keyword", "ignore_above": 100 },
     "message": { "type": "keyword", "ignore_above": 1024 },
     "message_type": { "type": "keyword", "ignore_above": 100 },
+    "user_query":  { "type": "keyword" },
     "timestamp": {
       "type": "date",
       "format":"strict_date_time",


### PR DESCRIPTION
update to events mapping to align with upcoming UBI spec 1.3.0

### Description
adds `user_query` field to the mapping of the events index as suggested in https://github.com/o19s/ubi/issues/35

### Issues Resolved
addresses the UBI plugin part of https://github.com/o19s/ubi/issues/35

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
