### PR TITLE
Removing old JDKs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        jdk: [ 11, 17, 21 ]
+        jdk: [ 21 ]
         experimental: [false]
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
### Description
Removes JDKs other than 21 from the GitHub Actions file.

### Issues Resolved
Closes #87 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
