### PR TITLE
Remove constraint on opensearch-py version to pick up latest

### DIFF
--- a/ubi-data-generator/requirements.txt
+++ b/ubi-data-generator/requirements.txt
@@ -1,4 +1,4 @@
-opensearch-py==2.8.0
+opensearch-py
 numpy
 pandas
 pyarrow


### PR DESCRIPTION
### Description
Constraining the version of opensearch may have made sense back in the 2x line, but we want the latest, so remove the constraint.

### Issues Resolved
Closes #110 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
