### PR TITLE
Update `opensearch_version` in build.gradle to 3.3.0-SNAPSHOT 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,7 @@ build
 build-idea/
 out/
 
+# vscode files
+.vscode/
+
 volumes/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "java.configuration.updateBuildConfiguration": "interactive"
-}


### PR DESCRIPTION
### Description
Update `opensearch_version` in build.gradle to 3.3.0-SNAPSHOT and also ignore pushing vscode files in `.gitignore`

### Issues Resolved
n/a

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
