### PR TITLE
Adapt ActionFilter interface implementation to core change

### DIFF
--- a/src/main/java/org/opensearch/ubi/UbiActionFilter.java
+++ b/src/main/java/org/opensearch/ubi/UbiActionFilter.java
@@ -23,6 +23,7 @@ import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.support.ActionFilter;
 import org.opensearch.action.support.ActionFilterChain;
+import org.opensearch.action.support.ActionRequestMetadata;
 import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.action.ActionResponse;
@@ -79,6 +80,7 @@ public class UbiActionFilter implements ActionFilter {
         Task task,
         String action,
         Request request,
+        ActionRequestMetadata<Request, Response> actionRequestMetadata,
         ActionListener<Response> listener,
         ActionFilterChain<Request, Response> chain
     ) {

--- a/src/test/java/org/opensearch/ubi/UbiActionFilterTests.java
+++ b/src/test/java/org/opensearch/ubi/UbiActionFilterTests.java
@@ -14,6 +14,7 @@ import org.opensearch.action.admin.indices.exists.indices.IndicesExistsResponse;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.support.ActionFilterChain;
+import org.opensearch.action.support.ActionRequestMetadata;
 import org.opensearch.common.action.ActionFuture;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
@@ -98,7 +99,7 @@ public class UbiActionFilterTests extends OpenSearchTestCase {
 
         when(request.source()).thenReturn(searchSourceBuilder);
 
-        ubiActionFilter.apply(task, "ubi", request, listener, chain);
+        ubiActionFilter.apply(task, "ubi", request, ActionRequestMetadata.empty(), listener, chain);
 
         verify(client, never()).index(any(), any());
 
@@ -157,7 +158,7 @@ public class UbiActionFilterTests extends OpenSearchTestCase {
 
         when(request.source()).thenReturn(searchSourceBuilder);
 
-        ubiActionFilter.apply(task, "ubi", request, listener, chain);
+        ubiActionFilter.apply(task, "ubi", request, ActionRequestMetadata.empty(), listener, chain);
 
         verify(client, atMostOnce()).index(any(), any());
 


### PR DESCRIPTION

### Description

The core PR https://github.com/opensearch-project/OpenSearch/pull/18523 has changed the `ActionFilter` interface by adding a new `apply()` method with an additional parameter. The old `apply()` method is now deprecated. This change adds the parameter to the ActionFilter implementations.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
