### PR TITLE
Proposing Martin G

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @epugh @jzonthemtn @msfroh @sstults
+* @epugh @jzonthemtn @msfroh @sstults @martin-gaievski

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -14,7 +14,7 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Jeff Zemerick | [jzonthemtn](https://github.com/jzonthemtn)                           | Mountain Fog |
 | Michael Froh | [msfroh](https://github.com/msfroh)                   | Uber      |
 | Scott Stults | [sstults](https://github.com/sstults)                   | OpenSource Connections      |
-
+| Martin Gaievski       | [martin-gaievski](https://github.com/martin-gaievski)         | Amazon      |
 ## Emeritus
 
 | Maintainer         | GitHub ID                                                 | Affiliation |


### PR DESCRIPTION
### Description
Adding [martin-gaievski](https://github.com/martin-gaievski)  as a maintainer.   Martin has worked extensively on the related `search-relevance` plugin, and is well known to [epugh](https://github.com/epugh), [msfroh](https://github.com/msfroh) , and [sstults](https://github.com/sstults).    

He will help us have more depth in maintaining up to date release and build tooling.  Plus as UBI matures, his java skills will be very valuable.

### Issues Resolved
n/a

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
