### PR TITLE
Removing opensearch-job-scheduler dependency.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Bump OpenSearch to 3.7.0-SNAPSHOT. ([#179](https://github.com/opensearch-project/user-behavior-insights/pull/179))
 - Update Jackson to 3.1.2. ([#174](https://github.com/opensearch-project/user-behavior-insights/pull/174))
 - Upgrade Gradle wrapper from 9.2.0 to 9.4.1. ([#180](https://github.com/opensearch-project/user-behavior-insights/pull/180))
+- Removed opensearch-scheduler dependency. ([#187](https://github.com/opensearch-project/user-behavior-insights/pull/187))
 
 ### Refactoring
 - Replace Mockito-based `XContent` stubbing in `UbIParametersTests` with a real JSON serialize/parse roundtrip. ([#179](https://github.com/opensearch-project/user-behavior-insights/pull/180))

--- a/build.gradle
+++ b/build.gradle
@@ -84,7 +84,6 @@ dependencies {
     api "org.apache.httpcomponents:httpcore:${versions.httpcore}"
     api "org.apache.httpcomponents:httpclient:${versions.httpclient}"
     api "commons-logging:commons-logging:${versions.commonslogging}"
-    zipArchive group: 'org.opensearch.plugin', name:'opensearch-job-scheduler', version: "${opensearch_build}"
 
     testImplementation("org.opensearch:opensearch-agent-bootstrap:${opensearch_version}")
 


### PR DESCRIPTION
### Description
Removes unneeded dependency

### Issues Resolved
Closes #186 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
